### PR TITLE
FEAT: Watch block interval and mutation callback updates

### DIFF
--- a/src/hooks/useWatchQuery.ts
+++ b/src/hooks/useWatchQuery.ts
@@ -1,7 +1,8 @@
-import { useBlockNumber } from "wagmi";
-import { useChain } from "./useChain";
 import { useEffect } from "react";
 import { QueryKey, useQueryClient } from "@tanstack/react-query";
+import { useBlockNumber } from "wagmi";
+import { mainnet } from "viem/chains";
+import { useChain } from "./useChain";
 
 export type UseWatchQueryArgs =
   | {
@@ -21,7 +22,8 @@ export const useWatchQuery = ({ queryKey, queryKeys }: UseWatchQueryArgs) => {
     watch: true,
   });
   useEffect(() => {
-    if (blockNumber) {
+    const isETH = chain.id === mainnet.id;
+    if (blockNumber && (isETH || Number(blockNumber) % 5 === 0)) {
       if (queryKey) {
         queryClient.invalidateQueries({ queryKey });
         return;
@@ -30,5 +32,5 @@ export const useWatchQuery = ({ queryKey, queryKeys }: UseWatchQueryArgs) => {
         queryClient.invalidateQueries({ queryKey: key });
       });
     }
-  }, [blockNumber, queryClient, queryKey, queryKeys]);
+  }, [blockNumber, chain.id, queryClient, queryKey, queryKeys]);
 };

--- a/src/utils/helpers/mutationCallback.test.ts
+++ b/src/utils/helpers/mutationCallback.test.ts
@@ -1,18 +1,49 @@
-import { WaitForTransactionReceiptTimeoutError, stringToHex } from "viem";
-import { it, expect } from "vitest";
+import {
+  TransactionNotFoundError,
+  WaitForTransactionReceiptTimeoutError,
+  stringToHex,
+} from "viem";
+import { describe, it, expect } from "vitest";
 
-it("Should pass if error is instance of WaitForTransactionReceiptTimeoutError", () => {
-  const mockHash = stringToHex("");
-  const thrownErrorInCallback = new WaitForTransactionReceiptTimeoutError({
-    hash: mockHash,
+describe("mutationCallback", () => {
+  it("Error is instance of WaitForTransactionReceiptTimeoutError", () => {
+    const mockHash = stringToHex("");
+    const thrownErrorInCallback = new WaitForTransactionReceiptTimeoutError({
+      hash: mockHash,
+    });
+
+    expect(thrownErrorInCallback).toBeInstanceOf(
+      WaitForTransactionReceiptTimeoutError,
+    );
+
+    const isInstanceOf =
+      thrownErrorInCallback instanceof WaitForTransactionReceiptTimeoutError;
+
+    expect(isInstanceOf).toBe(true);
   });
 
-  expect(thrownErrorInCallback).toBeInstanceOf(
-    WaitForTransactionReceiptTimeoutError,
-  );
+  it("Error is instance of TransactionNotFoundError", () => {
+    const mockHash = stringToHex("");
+    const thrownErrorInCallback = new TransactionNotFoundError({
+      hash: mockHash,
+    });
 
-  const isInstanceOf =
-    thrownErrorInCallback instanceof WaitForTransactionReceiptTimeoutError;
+    expect(thrownErrorInCallback).toBeInstanceOf(TransactionNotFoundError);
 
-  expect(isInstanceOf).toBe(true);
+    const isInstanceOf =
+      thrownErrorInCallback instanceof TransactionNotFoundError;
+
+    expect(isInstanceOf).toBe(true);
+  });
+
+  it("Error is not instance of TransactionNotFoundError", () => {
+    const thrownErrorInCallback = new Error("Some other error");
+
+    expect(thrownErrorInCallback).not.toBeInstanceOf(TransactionNotFoundError);
+
+    const isInstanceOf =
+      thrownErrorInCallback instanceof TransactionNotFoundError;
+
+    expect(isInstanceOf).toBe(false);
+  });
 });


### PR DESCRIPTION
- Invalidate queries each block on ETH and each 5 blocks on L2s;
- Check mutation receipt status and improve error handling.