### PR TITLE
FIX: Remove disabled vaults from list but not from query response

### DIFF
--- a/src/components/vaults/Vaults.tsx
+++ b/src/components/vaults/Vaults.tsx
@@ -54,10 +54,14 @@ export const Vaults = () => {
   };
 
   const filteredVaults = useMemo(() => {
+    const onlyEnabledVaults = vaults?.filter(
+      (vault) =>
+        vault.yieldTokenParams.enabled !== false || vault.position.shares > 0,
+    );
     const synthFiltered =
       synthTab === "all"
-        ? vaults
-        : [...(vaults ?? [])].filter(
+        ? onlyEnabledVaults
+        : onlyEnabledVaults?.filter(
             (vault) =>
               ALCHEMISTS_METADATA[chain.id][synthTab].toLowerCase() ===
               vault.alchemist.address.toLowerCase(),

--- a/src/lib/queries/useVaults.ts
+++ b/src/lib/queries/useVaults.ts
@@ -190,11 +190,6 @@ export const useVaults = () => {
 
       const vaultsWithTokenAdaptersAndMetadata = vaultsWithTokenAdapters
         .filter((vault) => VAULTS[chain.id][vault.yieldToken] !== undefined)
-        .filter(
-          (vault) =>
-            vault.yieldTokenParams.enabled !== false ||
-            vault.position.shares > 0,
-        )
         .map((vault) => {
           const metadata = VAULTS[chain.id][vault.yieldToken];
           return {


### PR DESCRIPTION
Fixes the case when user has deposit in disabled vaults, metrics would not show accurate info.