### PR TITLE
CHORE: Dependabot target branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "staging"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
Change target branch for dependabot. Targeting main, because doesn't change code and needs to be in main to be taken into account.