### PR TITLE
FIX: Minor refactor of approve reset and prevent flash to 0 deposit, when withdraw is less than max

### DIFF
--- a/src/components/vaults/row/VaultAccordionRow.tsx
+++ b/src/components/vaults/row/VaultAccordionRow.tsx
@@ -85,6 +85,9 @@ export const VaultAccordionRow = ({ vault }: { vault: Vault }) => {
         args: [vault.yieldToken, vault.position.shares],
       },
     ] as const,
+    query: {
+      placeholderData: keepPreviousData,
+    },
   });
   const [tvl, sharesBalance] = vaultStats ?? [0n, 0n];
 

--- a/src/hooks/useAllowance.ts
+++ b/src/hooks/useAllowance.ts
@@ -94,29 +94,27 @@ export const useAllowance = ({
     },
   });
 
-  const { writeContract: approve, data: approveTxHash } = useWriteContract({
+  const {
+    writeContract: approve,
+    data: approveTxHash,
+    reset: resetApprove,
+  } = useWriteContract({
     mutation: mutationCallback({
       action: "Approve",
     }),
   });
 
-  const { data: approvalReceipt, queryKey: approvalReceiptQueryKey } =
-    useWaitForTransactionReceipt({
-      chainId: chain.id,
-      hash: approveTxHash,
-    });
+  const { data: approvalReceipt } = useWaitForTransactionReceipt({
+    chainId: chain.id,
+    hash: approveTxHash,
+  });
 
   useEffect(() => {
     if (approvalReceipt) {
       queryClient.invalidateQueries({ queryKey: isApprovalNeededQueryKey });
-      queryClient.resetQueries({ queryKey: approvalReceiptQueryKey });
+      resetApprove();
     }
-  }, [
-    approvalReceipt,
-    isApprovalNeededQueryKey,
-    approvalReceiptQueryKey,
-    queryClient,
-  ]);
+  }, [approvalReceipt, isApprovalNeededQueryKey, resetApprove, queryClient]);
 
   return {
     isApprovalNeeded,

--- a/src/lib/mutations/useWithdraw.ts
+++ b/src/lib/mutations/useWithdraw.ts
@@ -151,16 +151,19 @@ export const useWithdraw = ({
     },
   });
 
-  const { writeContract: approve, data: approveHash } = useWriteContract({
+  const {
+    writeContract: approve,
+    data: approveHash,
+    reset: resetApprove,
+  } = useWriteContract({
     mutation: mutationCallback({
       action: "Approve",
     }),
   });
-  const { data: approvalReceipt, queryKey: approveQueryKey } =
-    useWaitForTransactionReceipt({
-      chainId: chain.id,
-      hash: approveHash,
-    });
+  const { data: approvalReceipt } = useWaitForTransactionReceipt({
+    chainId: chain.id,
+    hash: approveHash,
+  });
   useEffect(() => {
     if (approvalReceipt) {
       queryClient.invalidateQueries({
@@ -169,13 +172,13 @@ export const useWithdraw = ({
       queryClient.invalidateQueries({
         queryKey: isApprovalNeededWethGatewayQueryKey,
       });
-      queryClient.resetQueries({ queryKey: approveQueryKey });
+      resetApprove();
     }
   }, [
     approvalReceipt,
     isApprovalNeededAaveGatewayQueryKey,
     isApprovalNeededWethGatewayQueryKey,
-    approveQueryKey,
+    resetApprove,
     queryClient,
   ]);
 


### PR DESCRIPTION
Refactor reasoning: I think it makes more sense to reset mutation, that holds the transaction hash instead of resetting receipt query. Mutation reset will remove data (hash) which will reset the receipt. But when resetting receipt query, we can accidentally pass stale hash again and it will trigger infinite rerenders because of receipt used in useEffect.

Keep previous data reasoning: closes #146