### PR TITLE
FIX: Initial render of Historical APR Graph

### DIFF
--- a/src/components/vaults/row/AprHistoricalChart.tsx
+++ b/src/components/vaults/row/AprHistoricalChart.tsx
@@ -120,6 +120,7 @@ const AprHistoricalGraph = ({ width, height, data }: AreaProps) => {
 
   const avg = data.reduce((acc, cur) => acc + cur.apr, 0) / data.length;
 
+  if (width === 0) return null;
   return (
     <>
       <svg width={width} height={height}>


### PR DESCRIPTION
Initial render of Historical APR graph throwing error, because the initial width is 0.
This causes calculation to get a negative width value for `<rect />` element of chart.