### PR TITLE
FEAT: Only allow EOA Coinbase wallet

### DIFF
--- a/src/lib/wagmi/wagmiConfig.ts
+++ b/src/lib/wagmi/wagmiConfig.ts
@@ -14,6 +14,9 @@ import { chains } from "./chains";
 
 const projectId = import.meta.env.VITE_WC_PROJECT_ID;
 
+// Alchemix v2 doesn't support contract wallets
+coinbaseWallet.preference = "eoaOnly";
+
 const connectors = connectorsForWallets(
   [
     {


### PR DESCRIPTION
Alchemix v2 doesn't support smart contract wallets without whitelist.