### PR TITLE
FEAT: Add WETH gateway for apxETH

### DIFF
--- a/src/lib/config/vaults.ts
+++ b/src/lib/config/vaults.ts
@@ -332,6 +332,7 @@ export const VAULTS: VaultsConfig = {
       yieldSymbol: "apxETH",
       image: "apxETH.png",
       messages: [],
+      wethGateway: "0xA22a7ec2d82A471B1DAcC4B37345Cf428E76D67A",
       api: {
         apr: getDineroApr,
         yieldType: "APR",


### PR DESCRIPTION
Add WETH gateway for apxETH vault.
Allows users to deposit/withdraw native ETH.