### PR TITLE
FEAT: Separate timestamps for melted rewards

### DIFF
--- a/src/lib/config/metadataTypes.ts
+++ b/src/lib/config/metadataTypes.ts
@@ -49,7 +49,6 @@ export type VaultMessage = {
 };
 
 type ApiProvider =
-  | "meltedRewards"
   | "aave"
   | "yearn"
   | "frax"

--- a/src/lib/config/rewardRouterAddresses.ts
+++ b/src/lib/config/rewardRouterAddresses.ts
@@ -26,7 +26,7 @@ export const BONUS_REWARDS_END_TIMESTAMPS: Record<
     // Aave aUSDC
     "0x4186Eb285b1efdf372AC5896a08C346c7E373cC4": 1734048000,
     // Lido wstETH
-    "0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb": 1749600000,
+    "0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb": 1752192000,
   },
   // September 28th
   [arbitrum.id]: {

--- a/src/lib/config/rewardRouterAddresses.ts
+++ b/src/lib/config/rewardRouterAddresses.ts
@@ -17,9 +17,26 @@ export const REWARD_TOKENS = {
   },
 } as const;
 
-export const BONUS_REWARDS_END_TIMESTAMPS = {
+export const BONUS_REWARDS_END_TIMESTAMPS: Record<
+  typeof optimism.id | typeof arbitrum.id,
+  Record<`0x${string}`, number>
+> = {
   // December 13th
-  [optimism.id]: 1734048000,
+  [optimism.id]: {
+    // Aave aUSDC
+    "0x4186Eb285b1efdf372AC5896a08C346c7E373cC4": 1734048000,
+    // Lido wstETH
+    "0x1F32b1c2345538c0c6f582fCB022739c4A194Ebb": 1749600000,
+  },
   // September 28th
-  [arbitrum.id]: 1733315207,
+  [arbitrum.id]: {
+    // Aave aUSDC
+    "0x248a431116c6f6FCD5Fe1097d16d0597E24100f5": 1733315207,
+    // Jones jUSDC
+    "0xB0BDE111812EAC913b392D80D51966eC977bE3A2": 1733315207,
+    // Lido wstETH
+    "0x5979D7b546E38E414F7E9822514be443A4800529": 1733315207,
+    // Gearbox WETH
+    "0xf3b7994e4dA53E04155057Fd61dc501599d57877": 1733315207,
+  },
 };

--- a/src/lib/config/vaults.ts
+++ b/src/lib/config/vaults.ts
@@ -452,8 +452,8 @@ export const VAULTS: VaultsConfig = {
       api: {
         apr: getYearnApy,
         yieldType: "APY",
-        provider: "meltedRewards",
-        bonus: getMeltedRewardsBonusData,
+        provider: "yearn",
+        bonus: getNoBonus,
       },
       disabledDepositTokens: [],
       disabledWithdrawTokens: [],
@@ -514,7 +514,7 @@ export const VAULTS: VaultsConfig = {
       api: {
         apr: getLidoApy,
         yieldType: "APR",
-        provider: "meltedRewards",
+        provider: "lido",
         bonus: getMeltedRewardsBonusData,
       },
       disabledDepositTokens: [],
@@ -539,8 +539,8 @@ export const VAULTS: VaultsConfig = {
       api: {
         apr: getYearnApy,
         yieldType: "APY",
-        provider: "meltedRewards",
-        bonus: getMeltedRewardsBonusData,
+        provider: "yearn",
+        bonus: getNoBonus,
       },
       disabledDepositTokens: [],
       disabledWithdrawTokens: [],

--- a/src/lib/middleware/bonuses.ts
+++ b/src/lib/middleware/bonuses.ts
@@ -111,7 +111,17 @@ export const getMeltedRewardsBonusData: BonusFn = async ({
   const bonusYieldTokenSymbol = REWARD_TOKENS[chainId].rewardTokenSymbol;
   const bonusTimeLimit = true;
 
-  const rewardEnd = dayjs.unix(BONUS_REWARDS_END_TIMESTAMPS[chainId]);
+  const rewardEndTimestamp =
+    BONUS_REWARDS_END_TIMESTAMPS[chainId][vault.address];
+
+  if (!rewardEndTimestamp)
+    throw new Error(
+      `Reward end timestamp is not set up for ${vault.metadata.label}`,
+    );
+
+  const rewardEnd = dayjs.unix(
+    BONUS_REWARDS_END_TIMESTAMPS[chainId][vault.address],
+  );
   const distributionTimeAmount = rewardEnd.diff(dayjs(), "days");
 
   const distributionTimeUnit = distributionTimeAmount > 1 ? "days" : "day";


### PR DESCRIPTION
Separate timestamps for melted rewards. 
We need this because we only prolong rewards for lido wstETH vault on optimism.
This goes straight to main because of new vault ready to be merged on staging.