### PR TITLE
FIX: Wrong vault configuration on ethereum

### DIFF
--- a/src/lib/config/metadataTypes.ts
+++ b/src/lib/config/metadataTypes.ts
@@ -59,7 +59,7 @@ type ApiProvider =
   | "jones"
   | "dinero";
 
-export interface VaultMetadata {
+interface VaultMetadataBase {
   label: string;
   image: string;
   synthAssetType: SynthAsset;
@@ -75,17 +75,35 @@ export interface VaultMetadata {
   disabledDepositTokens: Address[];
   disabledWithdrawTokens: Address[];
   wethGateway?: Address;
-  gateway?: Address;
+  strategy?: string;
+  beta?: boolean;
+}
+
+interface VaultMetadataWithYieldTokenOverride extends VaultMetadataBase {
+  gateway: Address;
   /**
    * This is the address of the actual yield (bearing for aave) token,
    * the regular yield token address in this case becomes a (static token adapter for aave or staking token for yearn),
    * that we use for the vaults.
    * If it exists, means the vault is using (static token adapter for aave or staking token for yearn).
    */
-  yieldTokenOverride?: Address;
-  strategy?: string;
-  beta?: boolean;
+  yieldTokenOverride: Address;
 }
+
+interface VaultMetadataWithoutYieldTokenOverride extends VaultMetadataBase {
+  gateway?: never;
+  /**
+   * This is the address of the actual yield (bearing for aave) token,
+   * the regular yield token address in this case becomes a (static token adapter for aave or staking token for yearn),
+   * that we use for the vaults.
+   * If it exists, means the vault is using (static token adapter for aave or staking token for yearn).
+   */
+  yieldTokenOverride?: never;
+}
+
+export type VaultMetadata =
+  | VaultMetadataWithYieldTokenOverride
+  | VaultMetadataWithoutYieldTokenOverride;
 
 /**
  * Handle fetching APR data

--- a/src/lib/config/vaults.ts
+++ b/src/lib/config/vaults.ts
@@ -97,6 +97,7 @@ export const VAULTS: VaultsConfig = {
       image: "aDAI.svg",
       messages: [],
       yieldTokenOverride: "0x028171bCA77440897B824Ca71D1c56caC55b68A3",
+      gateway: "0x67EC822A2F981Ef2db6Afce4E8dF57ff1439f4d3",
       api: {
         apr: getAaveApr,
         yieldType: "APR",
@@ -114,6 +115,7 @@ export const VAULTS: VaultsConfig = {
       image: "aUSDC.svg",
       messages: [],
       yieldTokenOverride: "0xBcca60bB61934080951369a648Fb03DF4F96263C",
+      gateway: "0x67EC822A2F981Ef2db6Afce4E8dF57ff1439f4d3",
       api: {
         apr: getAaveApr,
         yieldType: "APR",
@@ -131,6 +133,7 @@ export const VAULTS: VaultsConfig = {
       image: "aUSDT.svg",
       messages: [],
       yieldTokenOverride: "0x3Ed3B47Dd13EC9a98b44e6204A523E766B225811",
+      gateway: "0x67EC822A2F981Ef2db6Afce4E8dF57ff1439f4d3",
       api: {
         apr: getAaveApr,
         yieldType: "APR",
@@ -212,6 +215,7 @@ export const VAULTS: VaultsConfig = {
       image: "aFRAX.svg",
       messages: [],
       yieldTokenOverride: "0xd4937682df3C8aEF4FE912A96A74121C0829E664",
+      gateway: "0x67EC822A2F981Ef2db6Afce4E8dF57ff1439f4d3",
       api: {
         apr: getAaveApr,
         yieldType: "APR",
@@ -247,7 +251,6 @@ export const VAULTS: VaultsConfig = {
       image: "wstETH.svg",
       messages: [],
       wethGateway: "0xA22a7ec2d82A471B1DAcC4B37345Cf428E76D67A",
-      gateway: "0xA22a7ec2d82A471B1DAcC4B37345Cf428E76D67A",
       api: {
         apr: getLidoApy,
         yieldType: "APR",
@@ -283,6 +286,7 @@ export const VAULTS: VaultsConfig = {
       messages: [],
       wethGateway: "0xA22a7ec2d82A471B1DAcC4B37345Cf428E76D67A",
       yieldTokenOverride: "0x030bA81f1c18d280636F32af80b9AAd02Cf0854e",
+      gateway: "0xA067C885d958aec176eC3D8dAdc847e0c9384809",
       api: {
         apr: getAaveApr,
         yieldType: "APR",


### PR DESCRIPTION
- Missing config for Aave vaults;
- Redundant gateway for lido vault.