### PR TITLE
CHORE: Bump vite in response to dependabot security

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,14 +82,9 @@
     "tailwindcss": "^3.4.14",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.7.2",
-    "vite": "^5.4.11",
+    "vite": "^5.4.12",
     "vite-plugin-svgr": "^4.3.0",
     "vitest": "^3.0.5"
-  },
-  "pnpm": {
-    "overrides": {
-      "nanoid": "3.3.8"
-    }
   },
   "lint-staged": {
     "**/*.(ts|tsx|js)": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  nanoid: 3.3.8
-
 importers:
 
   .:
@@ -152,7 +149,7 @@ importers:
         version: 1.43.10(@tanstack/react-router@1.90.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(csstype@3.1.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/router-plugin':
         specifier: ^1.85.3
-        version: 1.85.3(vite@5.4.11(@types/node@22.13.1)(terser@5.37.0))
+        version: 1.85.3(vite@5.4.14(@types/node@22.13.1)(terser@5.37.0))
       '@types/d3-array':
         specifier: ^3.2.1
         version: 3.2.1
@@ -170,7 +167,7 @@ importers:
         version: 7.18.0(eslint@8.57.0)(typescript@5.7.2)
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.1(vite@5.4.11(@types/node@22.13.1)(terser@5.37.0))
+        version: 4.3.1(vite@5.4.14(@types/node@22.13.1)(terser@5.37.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.39)
@@ -214,11 +211,11 @@ importers:
         specifier: ^5.7.2
         version: 5.7.2
       vite:
-        specifier: ^5.4.11
-        version: 5.4.11(@types/node@22.13.1)(terser@5.37.0)
+        specifier: ^5.4.12
+        version: 5.4.14(@types/node@22.13.1)(terser@5.37.0)
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.3.0(rollup@4.22.4)(typescript@5.7.2)(vite@5.4.11(@types/node@22.13.1)(terser@5.37.0))
+        version: 4.3.0(rollup@4.22.4)(typescript@5.7.2)(vite@5.4.14(@types/node@22.13.1)(terser@5.37.0))
       vitest:
         specifier: ^3.0.5
         version: 3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)(terser@5.37.0)
@@ -6359,8 +6356,8 @@ packages:
     peerDependencies:
       vite: '>=2.6.0'
 
-  vite@5.4.11:
-    resolution: {integrity: sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==}
+  vite@5.4.14:
+    resolution: {integrity: sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -9656,7 +9653,7 @@ snapshots:
       tsx: 4.19.2
       zod: 3.23.8
 
-  '@tanstack/router-plugin@1.85.3(vite@5.4.11(@types/node@22.13.1)(terser@5.37.0))':
+  '@tanstack/router-plugin@1.85.3(vite@5.4.14(@types/node@22.13.1)(terser@5.37.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.2
@@ -9677,7 +9674,7 @@ snapshots:
       unplugin: 1.16.0
       zod: 3.23.8
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.13.1)(terser@5.37.0)
+      vite: 5.4.14(@types/node@22.13.1)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10129,14 +10126,14 @@ snapshots:
       d3-time-format: 4.1.0
       internmap: 2.0.3
 
-  '@vitejs/plugin-react@4.3.1(vite@5.4.11(@types/node@22.13.1)(terser@5.37.0))':
+  '@vitejs/plugin-react@4.3.1(vite@5.4.14(@types/node@22.13.1)(terser@5.37.0))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.11(@types/node@22.13.1)(terser@5.37.0)
+      vite: 5.4.14(@types/node@22.13.1)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10147,13 +10144,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.5(vite@5.4.11(@types/node@22.13.1)(terser@5.37.0))':
+  '@vitest/mocker@3.0.5(vite@5.4.14(@types/node@22.13.1)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.13.1)(terser@5.37.0)
+      vite: 5.4.14(@types/node@22.13.1)(terser@5.37.0)
 
   '@vitest/pretty-format@3.0.5':
     dependencies:
@@ -14490,7 +14487,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.2
-      vite: 5.4.11(@types/node@22.13.1)(terser@5.37.0)
+      vite: 5.4.14(@types/node@22.13.1)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -14502,18 +14499,18 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-svgr@4.3.0(rollup@4.22.4)(typescript@5.7.2)(vite@5.4.11(@types/node@22.13.1)(terser@5.37.0)):
+  vite-plugin-svgr@4.3.0(rollup@4.22.4)(typescript@5.7.2)(vite@5.4.14(@types/node@22.13.1)(terser@5.37.0)):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.22.4)
       '@svgr/core': 8.1.0(typescript@5.7.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.7.2))
-      vite: 5.4.11(@types/node@22.13.1)(terser@5.37.0)
+      vite: 5.4.14(@types/node@22.13.1)(terser@5.37.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite@5.4.11(@types/node@22.13.1)(terser@5.37.0):
+  vite@5.4.14(@types/node@22.13.1)(terser@5.37.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.47
@@ -14526,7 +14523,7 @@ snapshots:
   vitest@3.0.5(@types/debug@4.1.12)(@types/node@22.13.1)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(vite@5.4.11(@types/node@22.13.1)(terser@5.37.0))
+      '@vitest/mocker': 3.0.5(vite@5.4.14(@types/node@22.13.1)(terser@5.37.0))
       '@vitest/pretty-format': 3.0.5
       '@vitest/runner': 3.0.5
       '@vitest/snapshot': 3.0.5
@@ -14542,7 +14539,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 5.4.11(@types/node@22.13.1)(terser@5.37.0)
+      vite: 5.4.14(@types/node@22.13.1)(terser@5.37.0)
       vite-node: 3.0.5(@types/node@22.13.1)(terser@5.37.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
bump vite and remove nanoid override (outdated)