### PR TITLE
FIX: Migration `migrateVault` params fix

### DIFF
--- a/src/lib/mutations/useMigrate.ts
+++ b/src/lib/mutations/useMigrate.ts
@@ -23,6 +23,7 @@ import { isInputZero } from "@/utils/inputNotZero";
 import { invalidateWagmiUseQueryPredicate } from "@/utils/helpers/invalidateWagmiUseQueryPredicate";
 import { calculateMinimumOut } from "@/utils/helpers/minAmountWithSlippage";
 import { getToastErrorMessage } from "@/utils/helpers/getToastErrorMessage";
+import { MAX_UINT256_BN } from "@/lib/constants";
 
 export const useMigrate = ({
   currentVault,
@@ -101,10 +102,20 @@ export const useMigrate = ({
   const [doesMigrationSucceed, reason, , newShares, newUnderlying] =
     migrationParams ?? [];
 
-  const minSharesForSlippage = calculateMinimumOut(
-    newShares,
-    parseUnits(slippage, 2),
-  );
+  const { data: minYieldForSlippage } = useReadContract({
+    address: currentVault.alchemist.address,
+    abi: alchemistV2Abi,
+    chainId: chain.id,
+    functionName: "convertSharesToYieldTokens",
+    args: [currentVault.yieldToken, newShares ?? MAX_UINT256_BN],
+    query: {
+      enabled: !!newShares,
+      select: (amountInYield) => {
+        return calculateMinimumOut(amountInYield, parseUnits(slippage, 2));
+      },
+    },
+  });
+
   const minUnderlyingForSlippage = calculateMinimumOut(
     newUnderlying,
     parseUnits(slippage, 2),
@@ -239,7 +250,7 @@ export const useMigrate = ({
       currentVault.address,
       selectedVault.address,
       parseUnits(amount, currentVault.yieldTokenParams.decimals),
-      minSharesForSlippage,
+      minYieldForSlippage ?? MAX_UINT256_BN,
       minUnderlyingForSlippage,
     ],
     query: {


### PR DESCRIPTION
Pass slippage applied minimum yield output token amount instead of minimum shares token amount.